### PR TITLE
added high-bit count support.

### DIFF
--- a/JtagAnalyzerResults.cpp
+++ b/JtagAnalyzerResults.cpp
@@ -81,7 +81,7 @@ void JtagAnalyzerResults::GenerateBubbleText(U64 frame_index, Channel& channel, 
 		// found?
 		if( sdi != mShiftedData.end() )
 		{
-			std::string tdi_tdo_result_string = ( channel == mSettings->mTdiChannel ? sdi->GetTDIString( display_base ).c_str() : sdi->GetTDOString( display_base ).c_str() );
+			std::string tdi_tdo_result_string = ( channel == mSettings->mTdiChannel ? sdi->GetTDIString( display_base, JtagShiftedData::TdiTdoStringFormat::Ellipsis256 ).c_str() : sdi->GetTDOString( display_base, JtagShiftedData::TdiTdoStringFormat::Ellipsis256 ).c_str() );
 
 			if( mSettings->mShowBitCount )
 			{
@@ -154,8 +154,8 @@ void JtagAnalyzerResults::GenerateExportFile(const char* file, DisplayBase displ
 			// found?
 			if (sdi != mShiftedData.end())
 			{
-				tdi_str = sdi->GetTDIString(display_base);
-				tdo_str = sdi->GetTDOString(display_base);
+				tdi_str = sdi->GetTDIString(display_base, JtagShiftedData::TdiTdoStringFormat::Break64 );
+				tdo_str = sdi->GetTDOString(display_base, JtagShiftedData::TdiTdoStringFormat::Break64 );
 
 				if( mSettings->mShowBitCount )
 				{
@@ -222,7 +222,7 @@ void JtagAnalyzerResults::GenerateFrameTabularText(U64 frame_index, DisplayBase 
         {
 			if( tdi_used == true )
 			{
-				std::string tdi_str = sdi->GetTDIString( display_base );
+				std::string tdi_str = sdi->GetTDIString( display_base, JtagShiftedData::TdiTdoStringFormat::Ellipsis256 );
 
 				if( mSettings->mShowBitCount )
 					tdi_str += " " + sdi->GetTDILengthString();
@@ -232,7 +232,7 @@ void JtagAnalyzerResults::GenerateFrameTabularText(U64 frame_index, DisplayBase 
 
 			if( tdo_used == true )
 			{
-				std::string tdo_str = sdi->GetTDOString( display_base );
+				std::string tdo_str = sdi->GetTDOString( display_base, JtagShiftedData::TdiTdoStringFormat::Ellipsis256 );
 
 				if( mSettings->mShowBitCount )
 					tdo_str += " " + sdi->GetTDOLengthString();

--- a/JtagTypes.h
+++ b/JtagTypes.h
@@ -59,24 +59,26 @@ public:
 // Contains data that is being shifted on TDI/TDO, and functions for converting that data to strings
 struct JtagShiftedData
 {
+	enum class TdiTdoStringFormat { SingleString, Break64, Ellipsis64, Break256, Ellipsis256 };
+
 	U64		mStartSampleIndex;
 
 	std::vector<U8>		mTdiBits;
 	std::vector<U8>		mTdoBits;
 
-	static std::string GetStringFromBitStates(const std::vector<U8>& bits, DisplayBase display_base);
+	static std::string GetStringFromBitStates(const std::vector<U8>& bits, DisplayBase display_base, TdiTdoStringFormat format );
 	static std::string GetDecimalString(const std::vector<U8>& bits);
 	static std::string GetASCIIString(const std::vector<U8>& bits);
 	static std::string GetHexOrBinaryString(const std::vector<U8>& bits, DisplayBase display_base);
 
-	std::string GetTDIString(DisplayBase display_base) const
+	std::string GetTDIString(DisplayBase display_base, TdiTdoStringFormat format = TdiTdoStringFormat::SingleString ) const
 	{
-		return GetStringFromBitStates(mTdiBits, display_base);
+		return GetStringFromBitStates(mTdiBits, display_base, format );
 	}
 
-	std::string GetTDOString(DisplayBase display_base) const
+	std::string GetTDOString(DisplayBase display_base, TdiTdoStringFormat format = TdiTdoStringFormat::SingleString ) const
 	{
-		return GetStringFromBitStates(mTdoBits, display_base);
+		return GetStringFromBitStates(mTdoBits, display_base, format );
 	}
 
 	std::string GetTDILengthString( bool with_parentheses = true ) const


### PR DESCRIPTION
Previously, Shift IR / DR states with large bit counts (over 1000, typically) could cause the software to become unresponsive.
3 changes are made:
1. graph overlay results are truncated to 64 bits
2. protocol search results are truncated to 256 bits
3. protocol-specific export is not truncated, but the output is formatted in 64 bit words, least significant word first. (i.e. the first 64 bit word on the bus is the first in the export)